### PR TITLE
Reformat email template for hotcrp mailer

### DIFF
--- a/EmailTemplates/artifact-submission-email-template.md
+++ b/EmailTemplates/artifact-submission-email-template.md
@@ -1,8 +1,13 @@
+Subject: Invitation to submit artifact for %TITLEHINT%
+
+Dear author(s),
 
 Hello and congratulations on your accepted PoPETs 2025 paper!
 
-PoPETs reviews and publishes digital artifacts related to its accepted papers. This process aids in the reproducibility of results and allows others to build on the work described in the paper. Artifact submissions
-are requested from authors of all accepted papers, and although they are optional, we strongly encourage you to submit your artifacts for review.
+%TITLE%
+%URL%/paper/%NUMBER%
+
+PoPETs reviews and publishes digital artifacts related to its accepted papers. This process aids in the reproducibility of results and allows others to build on the work described in the paper. Artifact submissions are requested from authors of all accepted papers, and although they are optional, we strongly encourage you to submit your artifacts for review.
 
 Artifacts can include source code for proofs of concept, measurements, simulations, datasets, and build environments. Anything you can think of that would help other researchers and developers of privacy enhancing technologies reproduce, build upon, or deploy your research is encouraged.
 
@@ -21,12 +26,10 @@ site for 2025.2:
 
 The next deadlines are:
 
-| What?                             |        When?  |
-|-----------------------------------|---------------|
-| Submission Deadline:              | Dec 13th 2024 |
-| Bidding Deadline:                 | Dec 20th 2024 |
-| Review Deadline:                  | Jan 13th 2025 |
-| Artifact Finalized Deadline:      | Jan 31st 2025 |
+Submission Deadline:          Dec 13th 2024
+Bidding Deadline:             Dec 20th 2024
+Review Deadline:              Jan 13th 2025
+Artifact Finalized Deadline:  Jan 31st 2025
 
 We have ensured that none of the deadlines fall on the holidays. That being said, please actively respond to reviewers' comments at your earliest convenience, so that your artifact can be awarded badge(s) by the Artifact Finalized Deadline.
 


### PR DESCRIPTION
HotCRP only supports plain text emails. Also, I added in the paper title and number information to give context to the authors for why they are receiving the invitation.